### PR TITLE
feat(copilot): return options from config module

### DIFF
--- a/lua/plugins/config/copilot.lua
+++ b/lua/plugins/config/copilot.lua
@@ -33,3 +33,5 @@ local options = {
   copilot_node_command = "node", -- Node.js version must be > 16.x
   server_opts_overrides = {}
 }
+
+return options


### PR DESCRIPTION
Add a return statement to the copilot configuration module for exporting options.