### PR TITLE
feat: Enhance gen.nvim plugin support and configuration

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -10,6 +10,7 @@
   "copilot.lua": { "branch": "master", "commit": "03f825956ec49e550d07875d867ea6e7c4dc8c00" },
   "dressing.nvim": { "branch": "master", "commit": "6f212262061a2120e42da0d1e87326e8a41c0478" },
   "friendly-snippets": { "branch": "main", "commit": "5cc1f45c6aac699ad008fb85f6ae03236062667d" },
+  "gen.nvim": { "branch": "main", "commit": "98043162168dcc0eb5c3c31b97439ff686dc8559" },
   "gitsigns.nvim": { "branch": "main", "commit": "2c2463dbd82eddd7dbab881c3a62cfbfbe3c67ae" },
   "hlargs.nvim": { "branch": "main", "commit": "e881f3a424139cc70c83121ec548732efdd67682" },
   "hop.nvim": { "branch": "v2", "commit": "90db1b2c61b820e230599a04fedcd2679e64bd07" },

--- a/lua/core/keybinds.lua
+++ b/lua/core/keybinds.lua
@@ -2,6 +2,9 @@ local map = vim.api.nvim_set_keymap
 local keymap = vim.keymap.set
 local silentMap = { noremap = true, silent = true }
 
+-- Create a keybind to :noh on <Esc>
+map("i", "<Esc>", ":noh<CR>", silentMap)
+
 -- Create tab keybind to indent in visual mode
 map("v", "<Tab>", ">gv", { noremap = true })
 map("v", "<S-Tab>", "<gv", { noremap = true })

--- a/lua/plugins/config/gen.lua
+++ b/lua/plugins/config/gen.lua
@@ -1,0 +1,15 @@
+local options = {
+  model = "codellama:13b-instruct",
+  display_mode = "float",
+  show_prompt = false,
+  show_model = false,
+  no_auto_close = false,
+  init = function(options)
+    pcall(io.popen, "ollama serve > /dev/null 2>&1 &")
+  end,
+  command = "curl --silent --no-buffer -X POST http://localhost:11434/api/generate -d $body",
+  list_models = "<omitted lua function>", -- Retrieves a list of model names
+  debug = false, -- Prints errors and the command which is run.
+}
+
+return options

--- a/lua/plugins/config/which_key.lua
+++ b/lua/plugins/config/which_key.lua
@@ -301,7 +301,7 @@ local mappings = {
       c = { "<cmd>Octo issue create<cr>", "Create Issue" },
     },
   },
-  J = {
+  j = {
     name = "Jester",
     r = { ":lua require'jester'.run()<cr>", "Run" },
     R = {

--- a/lua/plugins/gen.lua
+++ b/lua/plugins/gen.lua
@@ -1,0 +1,9 @@
+return {
+  "David-Kunz/gen.nvim",
+  opts = function()
+    return require("plugins.config.gen")
+  end,
+  config = function(_, opts)
+    require("gen").setup(opts)
+  end,
+}


### PR DESCRIPTION
- Add gen.nvim plugin to lockfile (lazy-lock)
- Add <Esc> mapping to clear highlights in insert mode (keybinds)
- Create new file `gen.lua` with initial configuration options for the plugin, including:
  - Model selection
  - Display mode
  - Prompt visibility
  - Auto-close behavior
  - Initialization function setup
  - Command setup for API interaction
  - Debug flag addition (gen.lua)
- Change key binding for Jester from 'J' to 'j' in which_key config (fix)
- Introduce new plugin configuration within `gen.lua` for enhanced customization (gen.lua)