### PR TITLE
feat(init.lua): add 'kk' to better-escape plugin mappings

### DIFF
--- a/lua/core/keybinds.lua
+++ b/lua/core/keybinds.lua
@@ -2,8 +2,10 @@ local map = vim.api.nvim_set_keymap
 local keymap = vim.keymap.set
 local silentMap = { noremap = true, silent = true }
 
--- Create a keybind to :noh on <Esc>
-map("i", "<Esc>", ":noh<CR>", silentMap)
+-- Before Escape when Esc is pressed in View Mode execute :noh
+map("n", "<Esc>", ":noh<CR>", silentMap)
+-- Change to normal mode when pressing O
+map("i", "<Esc>", "<Esc>", silentMap)
 
 -- Create tab keybind to indent in visual mode
 map("v", "<Tab>", ">gv", { noremap = true })

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -65,7 +65,7 @@ return {
     "max397574/better-escape.nvim",
     config = function()
       require("better_escape").setup {
-        mapping = { "jk", "jj", "kj" },
+        mapping = { "jk", "jj", "kj", "kk" },
         timeout = vim.o.timeoutlen,
         clear_empty_lines = true,
         keys = "<Esc>",


### PR DESCRIPTION
- Added a new key mapping 'kk' for the better-escape plugin to provide an alternative way for users to escape insert mode.

fix(keybinds): adjust noh keybind to normal mode and add normal escape
- The :noh command is now correctly bound to the <Esc> key in normal mode.
- Added a mapping for <Esc> in insert mode to ensure it behaves as expected, allowing users to return to normal mode.